### PR TITLE
Implement GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: LINT
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.JS
+        uses: actions/setup-node@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Python dependencies
+        run: |
+          npm install -g prettier
+          pipx install ruff
+
+      - name: Run prettier lint (Frontend)
+        run: |
+          cd frontend
+          prettier --check .
+
+      - name: Run ruff lint (Backend)
+        run: |
+          cd backend
+          ruff check --output-format=github .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: TESTS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Copy .env files
+        run: |
+          cp ./deployments/prod/conf/.env ./deployments/prod/conf/.env.local
+
+      - name: Build
+        run: make build
+
+      - name: Up
+        run: make up
+
+      - name: Test
+        run: make run-back-tests

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ clean: ## Clean up the production environment
 clean-volumes: ## Clean up the production environment volumes
 	@$(COMPOSE_PROD) down -v
 
-.PHONY: run-tests
-run-tests: ## Run tests for the production environment
+.PHONY: run-back-tests
+run-back-tests: ## Run backend (Django) tests for the production environment
 	@$(COMPOSE_PROD) exec backend sh -c \
 	"poetry run python manage.py test apps"
 


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows for linting and testing, along with a minor update to the `Makefile` to clarify the purpose of a test-related target. Below is a summary of the most important changes:

### GitHub Actions Workflows

* Added a `lint.yml` workflow to automate linting for both the frontend (using Prettier) and backend (using Ruff). This workflow is triggered on `push` and `workflow_dispatch` events. 
* Added a `tests.yml` workflow to automate running tests for the production environment. This workflow is triggered on `push` and `pull_request` events targeting the `main` branch, as well as manually via `workflow_dispatch`. 
### Makefile Update

* Renamed the `run-tests` target to `run-back-tests` in the `Makefile` to explicitly indicate that it runs backend (Django) tests.